### PR TITLE
Update ProyectoHistoriasClinicas_BACKLOG.txt

### DIFF
--- a/Documentos/ProyectoHistoriasClinicas_BACKLOG.txt
+++ b/Documentos/ProyectoHistoriasClinicas_BACKLOG.txt
@@ -10,8 +10,8 @@ ESTRUCTURACION DEL EQUIPO SCRUM
 
 CLIENTES DEL PROYECTO
 	Coordinador del Centro Médico
-        Médico del Turno Diurno
-        Médico del Turno Nocturno
+        Médico de Turno Diurno
+        Médico de Turno Nocturno
                       
         Interactuan con
 


### PR DESCRIPTION
Propongo cambiar en las líneas 13 y 14 la palabra "del" por "de":
Médico de turno diurno.
Médico de turno nocturno.